### PR TITLE
Add `virtual` to allow `_update` overridden implementations based on the ERC-7578

### DIFF
--- a/ERCS/erc-7578.md
+++ b/ERCS/erc-7578.md
@@ -218,7 +218,7 @@ contract ERC7578 is IERC7578, ERC721 {
      * to check if they are set before minting
      * @param tokenId The ID of the token being minted or burned
      */
-    function _update(address to, uint256 tokenId, address auth) internal override returns (address) {
+    function _update(address to, uint256 tokenId, address auth) internal virtual override returns (address) {
         address from = _ownerOf(tokenId);
         if (to == address(0)) {
             _removeProperties(tokenId);


### PR DESCRIPTION
Allow ERC-7578 inheriting contracts to override the `_update` method as they wish.